### PR TITLE
Refactor to run via npm instead of using global dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.vscode
+/dist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "gulp",
+    "server": "gulp server",
+    "js": "gulp js",
+    "html": "gulp html",
+    "sass": "gulp sass",
+    "watch": "gulp watch",
+    "uri": "gulp uri",
+    "pug:watch": "gulp pug-watch"
   },
   "author": "Ikhlaas Subratty",
   "license": "ISC",
@@ -15,14 +22,17 @@
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.1",
+    "gulp-express": "^0.3.5",
     "gulp-open": "^2.0.0",
+    "gulp-plumber": "^1.1.0",
     "gulp-pug": "^2.0.0",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.3.1",
     "gulp-uglify": "^1.5.3",
     "method-override": "^2.3.5",
+    "morgan": "^1.8.2",
     "pug": "^2.0.0-alpha6"
   },
-  "dependencies": {
-    "gulp-plumber": "^1.1.0"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
This PR is to refactor to using npm scripts instead of using gulp.

Using gulp from the command line requires the user to have `gulp` installed via `npm i gulp -g`

If the user does not have gulp installed globally the tasks will fail even if gulp is pulled in via the dependencies of the `package.json`.

Using npm allows the user to not have gulp installed as a global dependency.

Running `npm run js` will run the same task as typing `gulp js` in the command prompt but npm will fetch the locally installed gulp inside the `node_modules` folder instead of looking for a global dependency. This reduces the number of global installed node modules.

I also added some missing modules that were not specified in the `package.json`